### PR TITLE
fix(baselib): rename git.h.in to version.h.in

### DIFF
--- a/project/examples/baselib/src/baselib.cpp
+++ b/project/examples/baselib/src/baselib.cpp
@@ -2,7 +2,7 @@
 #include <fstream>
 #include <iostream>
 
-#include "git.h"
+#include "version.h"
 #include <baselib.h>
 
 


### PR DESCRIPTION
 

Fixes #20

## Proposed changes

* rename git.h.in to version.h.in for baselib
 
 
